### PR TITLE
identifiers + printable

### DIFF
--- a/Sources/Debuggable.swift
+++ b/Sources/Debuggable.swift
@@ -18,15 +18,23 @@ public protocol Debuggable: CustomDebugStringConvertible {
 
     // MARK: Identifiers
 
+    /// A readable name for the error's Type. This is usually
+    /// similar to the Type name of the error with spaces added.
+    /// This will normally be printed proceeding the error's reason.
     static var readableName: String { get }
 
+    /// Some unique identifier for the error's Type.
+    /// note: This defaults to `ModuleName.TypeName`
+    /// This will be used to create the `identifier` property.
     static var typeIdentifier: String { get }
 
+    /// Some unique identifier for this specific error.
+    /// This will be used to create the `identifier` property.
     var instanceIdentifier: String { get }
 
-    /// The identifier that describes the error at hand in the form of
-    /// `Module.Type.value`.
-    /// - note: A default implementation returns `String(reflecting: self)`.
+    /// The identifier that describes the specific error at hand
+    /// for use in finding help online.
+    /// - note: Default returns typeIdentifier.instanceIdentifier
     var identifier: String { get }
 
     // MARK: Help
@@ -57,7 +65,7 @@ public protocol Debuggable: CustomDebugStringConvertible {
     var gitHubIssues: [String] { get }
 }
 
-// MARK: Optional
+// MARK: Optionals
 
 extension Debuggable {
     public var possibleCauses: [String] {
@@ -81,7 +89,7 @@ extension Debuggable {
     }
 }
 
-// MARK: Default
+// MARK: Defaults
 
 extension Debuggable {
     public static var typeIdentifier: String {
@@ -96,7 +104,6 @@ extension Debuggable {
         return printable
     }
 }
-
 
 
 // MARK: Representations

--- a/Sources/Debuggable.swift
+++ b/Sources/Debuggable.swift
@@ -112,9 +112,7 @@ extension Debuggable {
     /// A computed property returning a `String` that encapsulates
     /// why the error occurred, suggestions on how to fix the problem,
     /// and resources to consult in debugging (if these are available).
-    /// - note: Consult the implementation of `generateDebugDescription()`
-    /// in `Debuggable`'s protocol extension for details on how
-    /// `log` is constructed by default.
+    /// - note: This representation is best used with functions like print()
     public var printable: String {
         var print: [String] = []
 

--- a/Tests/debuggingTests/DebuggingTests.swift
+++ b/Tests/debuggingTests/DebuggingTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import Debugging
+
+class DebuggingTests: XCTestCase {
+    func testBasic() {
+        let error = FooError.noFoo
+
+        print(error)
+    }
+}

--- a/Tests/debuggingTests/FooError.swift
+++ b/Tests/debuggingTests/FooError.swift
@@ -1,0 +1,55 @@
+enum FooError: String, Error {
+    case noFoo
+}
+
+import Debugging
+
+extension FooError: Debuggable {
+    static var readableName: String {
+        return "Foo Error"
+    }
+
+    var instanceIdentifier: String {
+        return rawValue
+    }
+
+    var reason: String {
+        switch self {
+        case .noFoo:
+            return "You do not have a `foo`."
+        }
+    }
+
+    var possibleCauses: [String] {
+        switch self {
+        case .noFoo:
+            return [
+                "You did not set the flongwaffle.",
+                "The session ended before a `Foo` could be made.",
+                "The universe conspires against us all.",
+                "Computers are hard."
+            ]
+        }
+    }
+
+    var suggestedFixes: [String] {
+        switch self {
+        case .noFoo:
+            return [
+                "You really want to use a `Bar` here.",
+                "Take up the guitar and move to the beach."
+            ]
+        }
+    }
+
+    var documentationLinks: [String] {
+        switch self {
+        case .noFoo:
+            return [
+                "http://documentation.com/Foo",
+                "http://documentation.com/foo/noFoo"
+            ]
+        }
+    }
+
+}

--- a/Tests/debuggingTests/debuggingTests.swift
+++ b/Tests/debuggingTests/debuggingTests.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import debugging
-
-class debuggingTests: XCTestCase {
-    
-}


### PR DESCRIPTION
This PR adds some additional identifier properties as well as returns conformance to `CustomStringConvertible`.

Getting the type information from `String(reflecting: self)` is really easy, but not being able to get useful output with `print(error)` could be an issue. I think that is how most people interact with errors that are difficult to debug.

Printing an error looks like this now:
```
Foo Error: You do not have a `foo`.

Identifier: DebuggingTests.FooError.noFoo

Here are some possible causes: 
- You did not set the flongwaffle.
- The session ended before a `Foo` could be made.
- The universe conspires against us all.
- Computers are hard.

These suggestions could address the issue: 
- You really want to use a `Bar` here.
- Take up the guitar and move to the beach.

Vapor's documentation talks about this: 
- http://documentation.com/Foo
- http://documentation.com/foo/noFoo
```

Most of the new additions have defaults, except for two

```swift
static var readableName: String {
    return "Foo Error"
}

var instanceIdentifier: String {
    return rawValue
}
```

The instance identifier is, as it sounds, an identifier for this specific case of the error. Conforming enums to `: String` gives an easy value for this.

Readable name provides a nice prefix to the reason for the error. `Foo Error: There was ...`. Some of our errors like `EntityError` are confusing without a readable name like `Database model error`

Additionally, I removed the `log: String` from the protocol since some representations may not come until higher level packages (for instance a JSON representation will be added in the JSON package or Vapor package). Having all representations as protocol extensions keeps this consistent. I also renamed it to `printable: String` since the string for writing to something like Apache or Nginx logs should probably not have as many line breaks